### PR TITLE
Fix settings modal and add theme support

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,13 @@ const EXCHANGE_URL = '/api/exchange'; // endpoint to exchange code for token
 let accessToken = localStorage.getItem('gh_token') || null;
 let currentRepo = JSON.parse(localStorage.getItem('current_repo') || 'null');
 let currentBranch = localStorage.getItem('current_branch');
+let theme = localStorage.getItem('theme') || 'light';
+
+function applyTheme() {
+    if(theme === 'dark') document.documentElement.classList.add('dark');
+    else document.documentElement.classList.remove('dark');
+}
+applyTheme();
 
 function showToast(msg, type='success', seconds=3, h=40, w=200, loc='upper middle') {
     const container = document.getElementById('toast-container');
@@ -31,11 +38,18 @@ function openSettings() {
     const modal = document.getElementById('settings-modal');
     modal.classList.remove('hidden');
     document.getElementById('auth-status').textContent = accessToken ? 'Connected' : 'Not connected';
-    document.getElementById('auth-btn').textContent = accessToken ? 'Disconnect' : 'Connect GitHub';
+    document.getElementById('auth-btn').textContent = accessToken ? '❌ Disconnect' : '🐙 Connect GitHub';
+    document.getElementById('theme-select').value = theme;
 }
 
 function closeSettings() {
     document.getElementById('settings-modal').classList.add('hidden');
+}
+
+function handleThemeChange() {
+    theme = document.getElementById('theme-select').value;
+    localStorage.setItem('theme', theme);
+    applyTheme();
 }
 
 function handleAuthBtn() {
@@ -50,10 +64,14 @@ function handleAuthBtn() {
 }
 
 function startOAuth() {
+    if(CLIENT_ID === 'YOUR_CLIENT_ID') {
+        showToast('Set CLIENT_ID in app.js', 'error', 3, 40, 200, 'upper middle');
+        return;
+    }
     const state = btoa(Math.random().toString(36).substring(2));
     localStorage.setItem('oauth_state', state);
     const authURL = `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=repo&state=${state}`;
-    window.location.href = authURL;
+    window.open(authURL, '_blank');
 }
 
 function handleRedirect() {
@@ -211,6 +229,7 @@ async function copySelected(){
 }
 
 document.addEventListener('DOMContentLoaded',()=>{
+    applyTheme();
     updateRepoLabels();
     handleRedirect();
     document.getElementById('settings-btn').onclick=openSettings;
@@ -222,4 +241,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     document.getElementById('repo-select').onchange=loadBranches;
     document.getElementById('copy-btn').onclick=copySelected;
     document.getElementById('refresh-btn').onclick=loadFileTree;
+    document.getElementById('theme-select').onchange=handleThemeChange;
+    document.getElementById('settings-modal').onclick=closeSettings;
+    document.getElementById('settings-content').onclick=e=>e.stopPropagation();
 });

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     </div>
 
     <div id="content">
-        <button id="copy-btn">Copy Selected</button>
+        <button id="copy-btn" class="big-btn">📋 Copy Selected</button>
         <div id="file-tree"></div>
     </div>
 
@@ -29,7 +29,7 @@
             <select id="repo-select"></select>
             <h2>Select Branch</h2>
             <select id="branch-select"></select>
-            <button id="modal-close">Close</button>
+            <button id="modal-close">✅ Confirm</button>
         </div>
     </div>
 
@@ -38,9 +38,16 @@
             <h2>Settings</h2>
             <div id="auth-section">
                 <p id="auth-status">Not connected</p>
-                <button id="auth-btn">Connect GitHub</button>
+                <button id="auth-btn" class="big-btn">🐙 Connect GitHub</button>
             </div>
-            <button id="settings-close">Close</button>
+            <div id="theme-section">
+                <label for="theme-select">Theme:</label>
+                <select id="theme-select">
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                </select>
+            </div>
+            <button id="settings-close">✖ Close</button>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -1,11 +1,26 @@
-body { font-family: Arial, sans-serif; margin: 0; }
-#top-bar { display: flex; justify-content: space-between; background:#f0f0f0; padding:5px; }
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --top-bar-bg: #f0f0f0;
+  --modal-bg: #ffffff;
+}
+
+.dark {
+  --bg-color: #222222;
+  --text-color: #ffffff;
+  --top-bar-bg: #333333;
+  --modal-bg: #444444;
+}
+
+body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); color: var(--text-color); }
+#top-bar { display: flex; justify-content: space-between; background: var(--top-bar-bg); padding:5px; }
 #repo-section { display: flex; gap: 5px; align-items: center; }
 #content { padding:10px; }
 #file-tree ul { list-style: none; padding-left: 20px; }
 #modal-overlay, #settings-modal { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
 .hidden { display:none; }
-#modal, #settings-content { background: white; padding: 20px; }
+#modal, #settings-content { background: var(--modal-bg); padding: 20px; }
+.big-btn { font-size: 1.1em; padding: 10px 16px; }
 #toast-container { position: fixed; width: 100%; pointer-events: none; }
 .toast { position: absolute; padding:4px 8px; color:white; }
 .toast.success { background: green; }


### PR DESCRIPTION
## Summary
- make action buttons larger and add emoji icons
- add theme selector to settings
- implement persistent light/dark theme
- open OAuth in a new tab and warn when CLIENT_ID isn't set
- dismiss settings modal by clicking outside

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68442c1c62d08325b03e6daeb4049eba