### PR TITLE
Fix settings modal handler and add GitHub OAuth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ A simple client-side web app to browse and copy files from your GitHub repositor
 
 ## Development
 
-1. Replace `YOUR_CLIENT_ID` in `app.js` with your GitHub OAuth App client ID.
+1. Set `window.GITHUB_CLIENT_ID` (or replace `YOUR_CLIENT_ID` in `app.js`) with your GitHub OAuth App client ID.
 2. Provide an endpoint at `EXCHANGE_URL` that exchanges OAuth codes for access tokens.
+   See [docs/GITHUB_OAUTH.md](docs/GITHUB_OAUTH.md) for a detailed setup guide.
 3. Serve the files with any static server.
 
 ## Usage

--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 // Configuration - replace with your GitHub OAuth app details
-const CLIENT_ID = 'YOUR_CLIENT_ID';
+// `GITHUB_CLIENT_ID` can be defined in a separate script tag to avoid
+// editing this file in production. Fallback to the placeholder string.
+const CLIENT_ID = window.GITHUB_CLIENT_ID || 'YOUR_CLIENT_ID';
 const REDIRECT_URI = window.location.origin + window.location.pathname;
 const EXCHANGE_URL = '/api/exchange'; // endpoint to exchange code for token
 
@@ -46,8 +48,9 @@ function openSettings() {
     document.getElementById('theme-select').value = theme;
 }
 
-function closeSettings() {
-    console.log('settings-close clicked');
+function closeSettings(e) {
+    // stopPropagation ensures the modal doesn't immediately reopen
+    if(e) e.stopPropagation();
     document.getElementById('settings-modal').classList.add('hidden');
 }
 
@@ -71,7 +74,7 @@ function handleAuthBtn() {
 
 function startOAuth() {
     if(CLIENT_ID === 'YOUR_CLIENT_ID') {
-        showToast('Set CLIENT_ID in app.js', 'error', 3, 40, 200, 'upper middle');
+        showToast('Configure GITHUB_CLIENT_ID before connecting', 'error', 3, 40, 200, 'upper middle');
         return;
     }
     const state = btoa(Math.random().toString(36).substring(2));
@@ -238,18 +241,18 @@ function init(){
     applyTheme();
     updateRepoLabels();
     handleRedirect();
-    document.getElementById('settings-btn').onclick=openSettings;
-    document.getElementById('settings-close').onclick=closeSettings;
-    document.getElementById('auth-btn').onclick=handleAuthBtn;
-    document.getElementById('repo-label').onclick=openRepoModal;
-    document.getElementById('branch-label').onclick=openRepoModal;
-    document.getElementById('modal-close').onclick=confirmRepoBranch;
-    document.getElementById('repo-select').onchange=loadBranches;
-    document.getElementById('copy-btn').onclick=copySelected;
-    document.getElementById('refresh-btn').onclick=loadFileTree;
-    document.getElementById('theme-select').onchange=handleThemeChange;
-    document.getElementById('settings-modal').onclick=closeSettings;
-    document.getElementById('settings-content').onclick=e=>e.stopPropagation();
+    document.getElementById('settings-btn').addEventListener('click', openSettings);
+    document.getElementById('settings-close').addEventListener('click', closeSettings);
+    document.getElementById('auth-btn').addEventListener('click', handleAuthBtn);
+    document.getElementById('repo-label').addEventListener('click', openRepoModal);
+    document.getElementById('branch-label').addEventListener('click', openRepoModal);
+    document.getElementById('modal-close').addEventListener('click', confirmRepoBranch);
+    document.getElementById('repo-select').addEventListener('change', loadBranches);
+    document.getElementById('copy-btn').addEventListener('click', copySelected);
+    document.getElementById('refresh-btn').addEventListener('click', loadFileTree);
+    document.getElementById('theme-select').addEventListener('change', handleThemeChange);
+    document.getElementById('settings-modal').addEventListener('click', closeSettings);
+    document.getElementById('settings-content').addEventListener('click', e=>e.stopPropagation());
 }
 
 init();

--- a/docs/GITHUB_OAUTH.md
+++ b/docs/GITHUB_OAUTH.md
@@ -1,0 +1,37 @@
+# GitHub OAuth Setup
+
+This project uses GitHub OAuth to access private repositories. The OAuth flow is handled entirely on the frontend with a small serverless token exchange.
+
+## Register an OAuth App
+1. Sign in to GitHub and navigate to **Settings → Developer settings → OAuth Apps**.
+2. Click **New OAuth App** and register the application.
+   - **Authorization Callback URL** should match your local dev URL (e.g. `http://localhost:3000`).
+3. After creation, note the **Client ID** and generate a **Client Secret**.
+
+## Flow Overview
+1. The app redirects the user to GitHub's authorization URL containing your Client ID, redirect URI, scopes and a random state string.
+2. GitHub redirects back with an authorization code.
+3. The code must be exchanged for an access token. Browsers cannot call GitHub's token endpoint directly, so use a small proxy (e.g. serverless function) that stores your **Client Secret** and performs the exchange.
+4. Use the returned token to request repository data via the GitHub API.
+5. Repositories are cached in IndexedDB for quick access on subsequent visits.
+
+A minimal proxy might look like:
+```js
+// pseudo serverless function
+const params = new URLSearchParams({
+  client_id: GITHUB_CLIENT_ID,
+  client_secret: GITHUB_CLIENT_SECRET,
+  code,
+  redirect_uri: REDIRECT_URI
+});
+return fetch('https://github.com/login/oauth/access_token', {
+  method: 'POST',
+  body: params,
+  headers: { 'Accept': 'application/json' }
+});
+```
+
+## Client Configuration
+Edit `app.js` and replace `YOUR_CLIENT_ID` with the Client ID from your OAuth app. Set `EXCHANGE_URL` to the URL of your token exchange proxy. Without these values the "Connect GitHub" button will display an error toast.
+
+


### PR DESCRIPTION
## Summary
- ensure settings modal closes properly using stopPropagation and event listeners
- allow setting OAuth client ID via `window.GITHUB_CLIENT_ID`
- update README with new instructions and link to docs
- add detailed `docs/GITHUB_OAUTH.md` explaining GitHub OAuth setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844325655048325960e3208961ef7ce