### PR TITLE
Implement GitHub OAuth server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.env

--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@ A simple client-side web app to browse and copy files from your GitHub repositor
 
 ## Development
 
-1. Set `window.GITHUB_CLIENT_ID` (or replace `YOUR_CLIENT_ID` in `app.js`) with your GitHub OAuth App client ID.
+1. Set `window.GITHUB_CLIENT_ID` (or replace `YOUR_CLIENT_ID` in `app.js`) with
+   your GitHub OAuth App client ID.
 2. Provide an endpoint at `EXCHANGE_URL` that exchanges OAuth codes for access tokens.
-   See [docs/GITHUB_OAUTH.md](docs/GITHUB_OAUTH.md) for a detailed setup guide.
-3. Serve the files with any static server.
+   This repository now includes a small Node server (`server.js`) you can run locally:
+
+   ```bash
+   npm install
+   GITHUB_CLIENT_ID=<your_id> GITHUB_CLIENT_SECRET=<your_secret> node server.js
+   ```
+
+   The server hosts the static files and exposes `/api/exchange` used by the OAuth
+   flow. See [docs/GITHUB_OAUTH.md](docs/GITHUB_OAUTH.md) for full setup details.
+3. Open `http://localhost:3000` in your browser to use the app.
 
 ## Usage
 

--- a/docs/GITHUB_OAUTH.md
+++ b/docs/GITHUB_OAUTH.md
@@ -32,6 +32,12 @@ return fetch('https://github.com/login/oauth/access_token', {
 ```
 
 ## Client Configuration
-Edit `app.js` and replace `YOUR_CLIENT_ID` with the Client ID from your OAuth app. Set `EXCHANGE_URL` to the URL of your token exchange proxy. Without these values the "Connect GitHub" button will display an error toast.
+Edit `app.js` and replace `YOUR_CLIENT_ID` with the Client ID from your OAuth app. Set `EXCHANGE_URL` to the URL of your token exchange proxy. A simple Node server (`server.js`) is provided in this repo and exposes `/api/exchange` when run with your credentials:
+
+```bash
+GITHUB_CLIENT_ID=<your_id> GITHUB_CLIENT_SECRET=<your_secret> node server.js
+```
+
+Without these values the "Connect GitHub" button will display an error toast.
 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "contextplus",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname)));
+
+app.post('/api/exchange', async (req, res) => {
+  const { code } = req.body;
+  if (!code) return res.status(400).json({ error: 'Missing code' });
+  try {
+    const params = new URLSearchParams({
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+      redirect_uri: process.env.REDIRECT_URI || `${req.protocol}://${req.get('host')}`
+    });
+    const resp = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      body: params,
+      headers: { Accept: 'application/json' }
+    });
+    const data = await resp.json();
+    res.json(data);
+  } catch (err) {
+    console.error('Error exchanging code', err);
+    res.status(500).json({ error: 'Exchange failed' });
+  }
+});
+
+app.listen(PORT, () => console.log(`Server running at http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- add simple Node exchange server
- document how to run the OAuth server
- mention `npm install` step

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68443b7e68888325adaca4ab0fa4b763