### PR TITLE
Rewrite app for Netlify multi-user setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,27 @@
 # ContextPlus
 
-A simple client-side web app to browse and copy files from your GitHub repositories. It uses GitHub OAuth for authentication and stores repository data in IndexedDB.
+A simple client-side web app to browse and copy files from your GitHub repositories. It is hosted at <https://contextplus.netlify.app/> and stores data locally using IndexedDB.
 
 ## Development
 
-1. Set `window.GITHUB_CLIENT_ID` (or replace `YOUR_CLIENT_ID` in `app.js`) with
-   your GitHub OAuth App client ID.
-2. Provide an endpoint at `EXCHANGE_URL` that exchanges OAuth codes for access tokens.
-   This repository now includes a small Node server (`server.js`) you can run locally:
+To develop locally:
 
-   ```bash
-   npm install
-   GITHUB_CLIENT_ID=<your_id> GITHUB_CLIENT_SECRET=<your_secret> node server.js
-   ```
+```bash
+npm install
+node server.js
+```
 
-The server hosts the static files and exposes `/api/exchange` used by the OAuth
-flow. See [docs/GITHUB_OAUTH.md](docs/GITHUB_OAUTH.md) for full setup details.
-3. Open `http://localhost:3000` in your browser to use the app.
+Open `http://localhost:3000` in your browser. Each user supplies their own GitHub OAuth credentials inside the app.
 
 ### Deploying on Netlify
 
-1. Create environment variables `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` in
-   your Netlify site settings.
-2. Deploy the repository. Netlify runs `generate-config.js` which writes
-   `config.js` using those variables and exposes a serverless function at
-   `/.netlify/functions/exchange`.
-3. Set your GitHub OAuth App callback URL to your Netlify site URL.
+Simply deploy this repository. Netlify runs `generate-config.js` which writes `config.js` and exposes a serverless function at `/.netlify/functions/exchange`.
 
 ## Usage
 
-- Click the settings gear to connect your GitHub account.
+- Click the settings gear and enter your GitHub OAuth **Client ID** and **Client Secret**.
+- Follow the on-screen instructions to create an OAuth App with `https://contextplus.netlify.app/` as the callback URL.
+- After saving your credentials, click **Connect GitHub** to authorize the app.
 - Select a repository and branch from the modal in the top-left.
 - Choose files or folders in the tree and press **Copy Selected** to place their contents on the clipboard.
 

--- a/config.js
+++ b/config.js
@@ -1,2 +1,1 @@
-window.GITHUB_CLIENT_ID = "YOUR_CLIENT_ID";
-window.EXCHANGE_URL = "/api/exchange";
+window.EXCHANGE_URL = "/.netlify/functions/exchange";

--- a/docs/GITHUB_OAUTH.md
+++ b/docs/GITHUB_OAUTH.md
@@ -1,17 +1,17 @@
 # GitHub OAuth Setup
 
-This project uses GitHub OAuth to access private repositories. The OAuth flow is handled entirely on the frontend with a small serverless token exchange.
+This project uses GitHub OAuth to access private repositories. The app is hosted at <https://contextplus.netlify.app/> and each user provides their own OAuth credentials which are stored locally in IndexedDB. A Netlify serverless function performs the code/token exchange.
 
 ## Register an OAuth App
 1. Sign in to GitHub and navigate to **Settings → Developer settings → OAuth Apps**.
 2. Click **New OAuth App** and register the application.
-   - **Authorization Callback URL** should match your local dev URL (e.g. `http://localhost:3000`).
+   - **Authorization Callback URL** must be `https://contextplus.netlify.app/`.
 3. After creation, note the **Client ID** and generate a **Client Secret**.
 
 ## Flow Overview
 1. The app redirects the user to GitHub's authorization URL containing your Client ID, redirect URI, scopes and a random state string.
 2. GitHub redirects back with an authorization code.
-3. The code must be exchanged for an access token. Browsers cannot call GitHub's token endpoint directly, so use a small proxy (e.g. serverless function) that stores your **Client Secret** and performs the exchange.
+3. The code must be exchanged for an access token. Browsers cannot call GitHub's token endpoint directly, so a serverless function receives your Client ID and Secret and performs the exchange.
 4. Use the returned token to request repository data via the GitHub API.
 5. Repositories are cached in IndexedDB for quick access on subsequent visits.
 
@@ -32,12 +32,6 @@ return fetch('https://github.com/login/oauth/access_token', {
 ```
 
 ## Client Configuration
-Edit `app.js` and replace `YOUR_CLIENT_ID` with the Client ID from your OAuth app (or create `config.js` with `window.GITHUB_CLIENT_ID`). Set `EXCHANGE_URL` (or `window.EXCHANGE_URL`) to the URL of your token exchange proxy. A simple Node server (`server.js`) is provided in this repo and exposes `/api/exchange` when run with your credentials:
-
-```bash
-GITHUB_CLIENT_ID=<your_id> GITHUB_CLIENT_SECRET=<your_secret> node server.js
-```
-
-Without these values the "Connect GitHub" button will display an error toast.
+Open the settings modal on first visit and enter your Client ID and Client Secret. The app stores them securely in your browser and uses the built-in Netlify function at `/.netlify/functions/exchange` to obtain an access token.
 
 

--- a/generate-config.js
+++ b/generate-config.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const clientId = process.env.GITHUB_CLIENT_ID || 'YOUR_CLIENT_ID';
-const exchange = process.env.EXCHANGE_URL || '/.netlify/functions/exchange';
-const content = `window.GITHUB_CLIENT_ID = "${clientId}";\nwindow.EXCHANGE_URL = "${exchange}";\n`;
+const exchange = '/.netlify/functions/exchange';
+const content = `window.EXCHANGE_URL = "${exchange}";\n`;
 fs.writeFileSync('config.js', content);

--- a/index.html
+++ b/index.html
@@ -40,6 +40,20 @@
                 <p id="auth-status">Not connected</p>
                 <button id="auth-btn" class="big-btn"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="icon"> Connect GitHub</button>
             </div>
+            <div id="cred-section">
+                <h3>GitHub OAuth Credentials</h3>
+                <label for="client-id-input">Client ID:</label>
+                <input id="client-id-input" type="text">
+                <label for="client-secret-input">Client Secret:</label>
+                <input id="client-secret-input" type="password">
+                <button id="save-creds" class="big-btn">💾 Save</button>
+                <p id="first-run" class="hidden instructions">
+                    1. Create a new OAuth App at GitHub → Settings → Developer settings → OAuth Apps.<br>
+                    2. Use <code>https://contextplus.netlify.app/</code> as the callback URL.<br>
+                    3. Paste the generated Client ID and Client Secret above then press <strong>Save</strong>.<br>
+                    4. Finally click <strong>Connect GitHub</strong>.
+                </p>
+            </div>
             <div id="theme-section">
                 <label for="theme-select">Theme:</label>
                 <select id="theme-select">

--- a/netlify/functions/exchange.js
+++ b/netlify/functions/exchange.js
@@ -2,16 +2,16 @@ exports.handler = async function(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: 'Method Not Allowed' };
   }
-  const { code } = JSON.parse(event.body || '{}');
-  if (!code) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Missing code' }) };
+  const { code, client_id, client_secret } = JSON.parse(event.body || '{}');
+  if (!code || !client_id || !client_secret) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Missing parameters' }) };
   }
   try {
     const params = new URLSearchParams({
-      client_id: process.env.GITHUB_CLIENT_ID,
-      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      client_id,
+      client_secret,
       code,
-      redirect_uri: process.env.REDIRECT_URI || event.headers['origin'] || ''
+      redirect_uri: 'https://contextplus.netlify.app/'
     });
     const resp = await fetch('https://github.com/login/oauth/access_token', {
       method: 'POST',

--- a/server.js
+++ b/server.js
@@ -8,14 +8,16 @@ app.use(express.json());
 app.use(express.static(path.join(__dirname)));
 
 app.post('/api/exchange', async (req, res) => {
-  const { code } = req.body;
-  if (!code) return res.status(400).json({ error: 'Missing code' });
+  const { code, client_id, client_secret } = req.body;
+  if (!code || !client_id || !client_secret) {
+    return res.status(400).json({ error: 'Missing parameters' });
+  }
   try {
     const params = new URLSearchParams({
-      client_id: process.env.GITHUB_CLIENT_ID,
-      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      client_id,
+      client_secret,
       code,
-      redirect_uri: process.env.REDIRECT_URI || `${req.protocol}://${req.get('host')}`
+      redirect_uri: 'https://contextplus.netlify.app/'
     });
     const resp = await fetch('https://github.com/login/oauth/access_token', {
       method: 'POST',

--- a/style.css
+++ b/style.css
@@ -23,6 +23,8 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 .big-btn { font-size: 1.1em; padding: 10px 16px; border-radius:6px; }
 button { border-radius:6px; cursor:pointer; }
 .icon { width:20px; height:20px; vertical-align:middle; margin-right:4px; }
+#cred-section input { width: 100%; padding: 4px; margin-bottom: 6px; }
+.instructions { font-size: 0.9em; line-height: 1.4; }
 #toast-container { position: fixed; width: 100%; pointer-events: none; }
 .toast { /* Toast visibility history: width fix v2 */
   position: absolute;


### PR DESCRIPTION
## Summary
- support passing GitHub OAuth credentials in requests
- store credentials per-user in IndexedDB
- add onboarding instructions in settings modal
- simplify config generation for Netlify
- document new workflow

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684444450cc08325802d8f106a075ce4