### PR TITLE
Update GitHub setup workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ Simply deploy this repository. Netlify runs `generate-config.js` which writes `c
 
 ## Usage
 
-- Click the settings gear and enter your GitHub OAuth **Client ID** and **Client Secret**.
-- Follow the on-screen instructions to create an OAuth App with `https://contextplus.netlify.app/` as the callback URL.
-- After saving your credentials, click **Connect GitHub** to authorize the app.
+- Open the settings gear and follow the on-screen instructions to create an OAuth App with `https://contextplus.netlify.app/` as the callback URL.
+- Enter your GitHub OAuth **Client ID** and **Client Secret**, then click **Connect GitHub** to authorize the app.
 - Select a repository and branch from the modal in the top-left.
 - Choose files or folders in the tree and press **Copy Selected** to place their contents on the clipboard.
 

--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ function openSettings() {
     } else {
         document.getElementById('auth-btn').innerHTML = '<img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="icon"> Connect GitHub';
     }
+    document.getElementById('first-run').classList.toggle('hidden', !!accessToken);
     document.getElementById('client-id-input').value = clientId || '';
     document.getElementById('client-secret-input').value = clientSecret || '';
     document.getElementById('theme-select').value = theme;
@@ -102,13 +103,8 @@ function handleThemeChange() {
     applyTheme();
 }
 
-async function handleSaveCreds() {
-    clientId = document.getElementById('client-id-input').value.trim();
-    clientSecret = document.getElementById('client-secret-input').value.trim();
-    await idbSet('client_id', clientId);
-    await idbSet('client_secret', clientSecret);
-    showToast('Credentials saved', 'success', 2, 40, 200, 'upper middle');
-    document.getElementById('first-run').classList.add('hidden');
+function openGitHubSettings(){
+    window.open('https://github.com/settings/developers', '_blank');
 }
 
 function handleAuthBtn() {
@@ -118,6 +114,10 @@ function handleAuthBtn() {
         accessToken = null;
         showToast('Disconnected', 'warning', 2, 40, 200, 'upper middle');
     } else {
+        clientId = document.getElementById('client-id-input').value.trim();
+        clientSecret = document.getElementById('client-secret-input').value.trim();
+        idbSet('client_id', clientId);
+        idbSet('client_secret', clientSecret);
         startOAuth();
     }
     closeSettings();
@@ -298,14 +298,17 @@ async function init(){
     applyTheme();
     updateRepoLabels();
     handleRedirect();
-    if(!clientId || !clientSecret){
+    if(!clientId || !clientSecret || !accessToken){
         openSettings();
+    }
+    if(!accessToken){
         document.getElementById('first-run').classList.remove('hidden');
     }
     document.getElementById('settings-btn').addEventListener('click', openSettings);
     document.getElementById('settings-close').addEventListener('click', closeSettings);
     document.getElementById('auth-btn').addEventListener('click', handleAuthBtn);
-    document.getElementById('save-creds').addEventListener('click', handleSaveCreds);
+    const ghBtn = document.getElementById('open-github');
+    if(ghBtn) ghBtn.addEventListener('click', openGitHubSettings);
     document.getElementById('repo-label').addEventListener('click', openRepoModal);
     document.getElementById('branch-label').addEventListener('click', openRepoModal);
     document.getElementById('modal-close').addEventListener('click', confirmRepoBranch);

--- a/index.html
+++ b/index.html
@@ -36,23 +36,21 @@
     <div id="settings-modal" class="hidden">
         <div id="settings-content">
             <h2>Settings</h2>
+            <p id="first-run" class="hidden instructions">
+                1. Create a new OAuth App at GitHub → Settings → Developer settings → OAuth Apps.
+                <button id="open-github" class="small-btn"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="icon">Open GitHub</button><br>
+                2. Use <code>https://contextplus.netlify.app/</code> as the callback URL.<br>
+                3. Paste the generated Client ID and Client Secret below.<br>
+                4. Finally click <strong>Connect GitHub</strong>.
+            </p>
+            <h3>GitHub OAuth Credentials</h3>
             <div id="auth-section">
                 <p id="auth-status">Not connected</p>
-                <button id="auth-btn" class="big-btn"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="icon"> Connect GitHub</button>
-            </div>
-            <div id="cred-section">
-                <h3>GitHub OAuth Credentials</h3>
                 <label for="client-id-input">Client ID:</label>
                 <input id="client-id-input" type="text">
                 <label for="client-secret-input">Client Secret:</label>
                 <input id="client-secret-input" type="password">
-                <button id="save-creds" class="big-btn">💾 Save</button>
-                <p id="first-run" class="hidden instructions">
-                    1. Create a new OAuth App at GitHub → Settings → Developer settings → OAuth Apps.<br>
-                    2. Use <code>https://contextplus.netlify.app/</code> as the callback URL.<br>
-                    3. Paste the generated Client ID and Client Secret above then press <strong>Save</strong>.<br>
-                    4. Finally click <strong>Connect GitHub</strong>.
-                </p>
+                <button id="auth-btn" class="big-btn"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="icon"> Connect GitHub</button>
             </div>
             <div id="theme-section">
                 <label for="theme-select">Theme:</label>

--- a/style.css
+++ b/style.css
@@ -21,9 +21,10 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 .hidden { display:none; }
 #modal, #settings-content { background: var(--modal-bg); padding: 20px; display:flex; flex-direction:column; gap:15px; }
 .big-btn { font-size: 1.1em; padding: 10px 16px; border-radius:6px; }
+.small-btn { font-size: 0.9em; padding: 4px 8px; border-radius:6px; }
 button { border-radius:6px; cursor:pointer; }
 .icon { width:20px; height:20px; vertical-align:middle; margin-right:4px; }
-#cred-section input { width: 100%; padding: 4px; margin-bottom: 6px; }
+#auth-section input { width: 100%; padding: 4px; margin-bottom: 6px; }
 .instructions { font-size: 0.9em; line-height: 1.4; }
 #toast-container { position: fixed; width: 100%; pointer-events: none; }
 .toast { /* Toast visibility history: width fix v2 */


### PR DESCRIPTION
## Summary
- show GitHub setup instructions at the top of settings when not connected
- add **Open GitHub** helper button and compact style
- remove standalone save button and save credentials on connect
- tweak docs for the new flow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68444994f68c8325a5c2eb7a4e4df0cf