### PR TITLE
Improve OAuth setup instructions

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,7 +104,7 @@ function handleThemeChange() {
 }
 
 function openGitHubSettings(){
-    window.open('https://github.com/settings/developers', '_blank');
+    window.open('https://github.com/settings/applications/new', '_blank');
 }
 
 function handleAuthBtn() {

--- a/index.html
+++ b/index.html
@@ -37,9 +37,9 @@
         <div id="settings-content">
             <h2>Settings</h2>
             <p id="first-run" class="hidden instructions">
-                1. Create a new OAuth App at GitHub → Settings → Developer settings → OAuth Apps.
+                1. Create a new OAuth App at GitHub → Settings → Developer settings → OAuth Apps.<br>
                 <button id="open-github" class="small-btn"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="icon">Open GitHub</button><br>
-                2. Use <code>https://contextplus.netlify.app/</code> as the callback URL.<br>
+                2. Use <code>https://contextplus.netlify.app/</code> for both the Homepage URL and the Authorization callback URL. Leave <em>Enable Device Flow</em> unchecked.<br>
                 3. Paste the generated Client ID and Client Secret below.<br>
                 4. Finally click <strong>Connect GitHub</strong>.
             </p>


### PR DESCRIPTION
## Summary
- tweak Open GitHub button layout and text in settings modal
- update instructions to include homepage URL and device flow guidance
- link directly to GitHub's New OAuth App page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68444c35b0b48325b8e0e9155a8c4604