### PR TITLE
Add debug logging for GitHub OAuth flow

### DIFF
--- a/netlify/functions/exchange.js
+++ b/netlify/functions/exchange.js
@@ -6,6 +6,7 @@ exports.handler = async function(event) {
   if (!code || !client_id || !client_secret) {
     return { statusCode: 400, body: JSON.stringify({ error: 'Missing parameters' }) };
   }
+  console.log('Exchange function body', { code, client_id });
   try {
     const params = new URLSearchParams({
       client_id,
@@ -19,6 +20,7 @@ exports.handler = async function(event) {
       headers: { Accept: 'application/json' }
     });
     const data = await resp.json();
+    console.log('Exchange function response', data);
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/server.js
+++ b/server.js
@@ -2,12 +2,14 @@ const express = require('express');
 const path = require('path');
 
 const app = express();
+const DEBUG = true;
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname)));
 
-app.post('/api/exchange', async (req, res) => {
+async function handleExchange(req, res) {
+  if(DEBUG) console.log('Exchange request body', req.body);
   const { code, client_id, client_secret } = req.body;
   if (!code || !client_id || !client_secret) {
     return res.status(400).json({ error: 'Missing parameters' });
@@ -25,11 +27,16 @@ app.post('/api/exchange', async (req, res) => {
       headers: { Accept: 'application/json' }
     });
     const data = await resp.json();
+    if(DEBUG) console.log('Exchange response', data);
     res.json(data);
   } catch (err) {
     console.error('Error exchanging code', err);
     res.status(500).json({ error: 'Exchange failed' });
   }
-});
+}
+
+// Support both the local "/api" path and the Netlify function path
+app.post('/api/exchange', handleExchange);
+app.post('/.netlify/functions/exchange', handleExchange);
 
 app.listen(PORT, () => console.log(`Server running at http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- add DEBUG flag and extensive console logging in `app.js`
- log requests/responses in Netlify function
- log requests/responses in local Express server and support Netlify path

## Testing
- `npm install`
- `node server.js` *(fails initially due to missing express, succeeds after install)*
- `node -c app.js`
- `node -c server.js`
- `node -c netlify/functions/exchange.js`


------
https://chatgpt.com/codex/tasks/task_e_68444f598d1c83258d1db3fbf361bf47