### PR TITLE
Handle saved credentials better

### DIFF
--- a/app.js
+++ b/app.js
@@ -176,12 +176,15 @@ function openRepoModal() {
         return;
     }
     const overlay = document.getElementById('modal-overlay');
+    overlay.style.display = 'flex';
     overlay.classList.remove('hidden');
     loadRepos();
 }
 
 function closeRepoModal() {
-    document.getElementById('modal-overlay').classList.add('hidden');
+    const overlay = document.getElementById('modal-overlay');
+    overlay.classList.add('hidden');
+    overlay.style.display = 'none';
 }
 
 function loadRepos() {
@@ -339,7 +342,7 @@ async function init(){
             loadFileTree();
         }
     }
-    if(!clientId || !clientSecret || !accessToken){
+    if(!clientId || !clientSecret){
         openSettings();
     }
     if(!accessToken){


### PR DESCRIPTION
## Summary
- hide repo picker modal correctly when confirming
- only auto-open settings when OAuth credentials are missing

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844538fc42483258e11c8babf24e34f