### PR TITLE
Add multi-column UI with instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
     <div id="top-bar">
         <div id="repo-section">
+            <span id="branch-icon">🌿</span>
             <span id="repo-label">No repo selected</span>
             <span id="branch-label"></span>
             <button id="refresh-btn" title="Refresh">&#x21bb;</button>
@@ -16,13 +17,30 @@
         <button id="settings-btn" title="Settings">&#9881;</button>
     </div>
 
-    <div id="content">
-        <button id="copy-btn" class="big-btn">📋 Copy Selected</button>
-        <div id="select-buttons">
-            <button id="select-all-btn" class="small-btn">Select All</button>
-            <button id="deselect-all-btn" class="small-btn">Deselect All</button>
+    <div id="columns">
+        <div id="files-col" class="column">
+            <h3>Files</h3>
+            <div id="select-buttons">
+                <button id="select-all-btn" class="small-btn">Select All</button>
+                <button id="deselect-all-btn" class="small-btn">Deselect All</button>
+            </div>
+            <div id="file-tree"></div>
         </div>
-        <div id="file-tree"></div>
+        <div id="instructions-col" class="column">
+            <h3>Instructions</h3>
+            <button id="create-instruction" class="small-btn">Create</button>
+            <div id="instructions-list"></div>
+        </div>
+        <div id="descriptions-col" class="column">
+            <h3>File Descriptions</h3>
+            <div id="desc-tree"></div>
+        </div>
+    </div>
+
+    <div id="output-col">
+        <h3 id="output-title">Output <span id="total-tokens"></span></h3>
+        <div id="output-cards"></div>
+        <button id="copy-btn" class="big-btn">📋 Copy Selected</button>
     </div>
 
     <div id="toast-container"></div>
@@ -64,6 +82,20 @@
                 </select>
             </div>
             <button id="settings-close">✖ Close</button>
+        </div>
+    </div>
+    <div id="instruction-modal" class="hidden">
+        <div id="instruction-content">
+            <h2>Instruction</h2>
+            <label for="instruction-title">Title</label>
+            <input id="instruction-title" type="text">
+            <label for="instruction-text">Instructions</label>
+            <textarea id="instruction-text" rows="6"></textarea>
+            <div class="modal-buttons">
+                <button id="instruction-save" class="small-btn">Save</button>
+                <button id="instruction-delete" class="small-btn">Delete</button>
+                <button id="instruction-close" class="small-btn">Close</button>
+            </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -15,8 +15,20 @@
 body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); color: var(--text-color); }
 #top-bar { display: flex; justify-content: space-between; background: var(--top-bar-bg); padding:10px; }
 #repo-section { display: flex; gap: 10px; align-items: center; }
-#content { padding:20px; }
+#columns { display:flex; border-top:1px solid #ccc; }
+.column { flex:1; padding:20px; border-right:1px solid #ccc; }
+.column:last-child { border-right:none; }
 #select-buttons { margin:10px 0; display:flex; gap:10px; }
+#output-col { padding:20px; text-align:center; margin-top:20px; }
+#output-cards { display:flex; flex-direction:column; align-items:center; gap:10px; }
+.card { background:var(--modal-bg); padding:10px; border-radius:6px; width:80%; cursor:grab; }
+.card.dragging { opacity:0.5; }
+#desc-tree ul{ list-style:none; padding-left:20px; }
+.desc-status{ margin-left:4px; }
+#copy-btn { margin-top:10px; width:90%; }
+#instruction-modal { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
+#instruction-content { background:var(--modal-bg); padding:20px; display:flex; flex-direction:column; gap:10px; width:300px; }
+.modal-buttons { display:flex; justify-content:space-between; }
 #file-tree ul { list-style: none; padding-left: 20px; }
 #modal-overlay, #settings-modal { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
 .hidden { display:none; }


### PR DESCRIPTION
## Summary
- overhaul layout with three columns and output section
- add modal for creating instructions
- store instructions in IndexedDB
- show file description tree with status icons
- drag cards in output column and compute token totals
- copy selected files, instructions and descriptions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684569c03528832588a9a1f109973815