### PR TITLE
Fix instruction modal behavior and editing

### DIFF
--- a/app.js
+++ b/app.js
@@ -144,6 +144,8 @@ function renderInstructions(){
         toggle.addEventListener('change', updateOutputCards);
         const span = document.createElement('span');
         span.textContent = instr.title;
+        span.className = 'instruction-title';
+        span.addEventListener('click', () => openInstructionModal(instr.id));
         div.appendChild(toggle);
         div.appendChild(span);
         list.appendChild(div);
@@ -185,14 +187,22 @@ function saveInstruction(){
     } else {
         store.add({title,text});
     }
-    store.transaction.oncomplete=()=>{ loadInstructions(); closeInstructionModal(); };
+    store.transaction.oncomplete=()=>{ 
+        loadInstructions(); 
+        closeInstructionModal(); 
+        showToast('Instruction saved','success',2,40,200,'upper middle');
+    };
 }
 
 function deleteInstruction(){
     if(currentInstructionId){
         const store = db.transaction('instructions','readwrite').objectStore('instructions');
         store.delete(currentInstructionId);
-        store.transaction.oncomplete=()=>{ loadInstructions(); closeInstructionModal(); };
+        store.transaction.oncomplete=()=>{ 
+            loadInstructions(); 
+            closeInstructionModal(); 
+            showToast('Instruction deleted','warning',2,40,200,'upper middle');
+        };
     } else {
         closeInstructionModal();
     }

--- a/style.css
+++ b/style.css
@@ -30,8 +30,9 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 #instruction-content { background:var(--modal-bg); padding:20px; display:flex; flex-direction:column; gap:10px; width:300px; }
 .modal-buttons { display:flex; justify-content:space-between; }
 #file-tree ul { list-style: none; padding-left: 20px; }
+#instructions-list span.instruction-title { cursor:pointer; text-decoration:underline; }
 #modal-overlay, #settings-modal { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
-.hidden { display:none; }
+.hidden { display:none !important; }
 #modal, #settings-content { background: var(--modal-bg); padding: 20px; display:flex; flex-direction:column; gap:15px; }
 .big-btn { font-size: 1.1em; padding: 10px 16px; border-radius:6px; }
 .small-btn { font-size: 0.9em; padding: 4px 8px; border-radius:6px; }


### PR DESCRIPTION
## Summary
- ensure `.hidden` overrides modal display
- allow editing instruction sets by clicking titles
- show toasts when saving or deleting an instruction
- style instruction titles as links

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68456f17442483258d8cb0f571c95457