### PR TITLE
Fix modal initialization and instruction close

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,6 +154,9 @@ function renderInstructions(){
     updateOutputCards();
 }
 
+// Instruction modal open bug fix history:
+// 1. Basic open with values populated.
+// 2. Ensured display is explicitly set so CSS doesn't override.
 function openInstructionModal(id=null){
     log('openInstructionModal', {id});
     currentInstructionId = id;
@@ -172,7 +175,11 @@ function openInstructionModal(id=null){
     modal.classList.remove('hidden');
 }
 
-function closeInstructionModal(){
+// Instruction modal close bug fix history:
+// 1. Initial implementation simply hid the element.
+// 2. Added optional event argument with stopPropagation to mirror settings modal.
+function closeInstructionModal(e){
+    if(e) e.stopPropagation();
     log('closeInstructionModal');
     const modal = document.getElementById('instruction-modal');
     modal.classList.add('hidden');
@@ -686,6 +693,7 @@ async function init(){
         if(el){
             el.classList.add('hidden');
             el.style.display='none';
+            log('init hide', id);
         }
     });
     applyTheme();

--- a/style.css
+++ b/style.css
@@ -31,6 +31,14 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 .modal-buttons { display:flex; justify-content:space-between; }
 #file-tree ul { list-style: none; padding-left: 20px; }
 #modal-overlay, #settings-modal { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
+
+/* Hide modals by default when the hidden class is present
+   (ID selectors otherwise override display:none) */
+#modal-overlay.hidden,
+#settings-modal.hidden,
+#instruction-modal.hidden {
+  display:none;
+}
 .hidden { display:none; }
 #modal, #settings-content { background: var(--modal-bg); padding: 20px; display:flex; flex-direction:column; gap:15px; }
 .big-btn { font-size: 1.1em; padding: 10px 16px; border-radius:6px; }


### PR DESCRIPTION
## Summary
- ensure modals remain hidden until shown
- allow closing the instruction modal with stopPropagation
- log modal hiding on init for easier debugging
- update CSS so hidden modals stay hidden

## Testing
- `npm install`
- `npm start` *(fails: Server running at http://localhost:3000)*

------
https://chatgpt.com/codex/tasks/task_e_684579a84d948325874f971b96f752d8