### PR TITLE
Fix instruction modal saving

### DIFF
--- a/app.js
+++ b/app.js
@@ -184,6 +184,9 @@ function renderInstructions(){
         toggle.addEventListener('change', updateOutputCards);
         const span = document.createElement('span');
         span.textContent = instr.title;
+        span.className = 'instruction-title';
+        span.style.cursor = 'pointer';
+        span.addEventListener('click', () => openInstructionModal(instr.id));
         div.appendChild(toggle);
         div.appendChild(span);
         list.appendChild(div);

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
             <label for="instruction-title">Title</label>
             <input id="instruction-title" type="text">
             <label for="instruction-text">Instructions</label>
-            <textarea id="instruction-text" rows="6"></textarea>
+            <textarea id="instruction-text" rows="12"></textarea>
             <div class="modal-buttons">
                 <button id="instruction-save" class="small-btn">Save</button>
                 <button id="instruction-delete" class="small-btn">Delete</button>

--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 .desc-status{ margin-left:4px; }
 #copy-btn { margin-top:10px; width:90%; }
 #instruction-modal { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
-#instruction-content { background:var(--modal-bg); padding:20px; display:flex; flex-direction:column; gap:10px; width:300px; }
+#instruction-content { background:var(--modal-bg); padding:20px; display:flex; flex-direction:column; gap:10px; width:600px; }
 .modal-buttons { display:flex; justify-content:space-between; }
 #file-tree ul { list-style: none; padding-left: 20px; }
 #modal-overlay, #settings-modal { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }


### PR DESCRIPTION
## Summary
- make instructions text box bigger
- enlarge instruction modal CSS
- allow editing instructions via title click

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6846c3be02048325919f933b9711e55d