### PR TITLE
Add startup loading spinner overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -794,6 +794,8 @@ async function init(){
     document.getElementById('instruction-content').addEventListener('click', e=>e.stopPropagation());
     loadInstructions();
     log('init listeners attached');
+    const overlay = document.getElementById('loading-overlay');
+    if (overlay) overlay.style.display = 'none';
 }
 
 init();

--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <div id="loading-overlay">
+        <div id="spinner">
+            <div></div><div></div><div></div><div></div><div></div><div></div>
+            <div></div><div></div><div></div><div></div><div></div><div></div>
+        </div>
+    </div>
     <div id="top-bar">
         <div id="repo-section">
             <span id="branch-icon">🌿</span>

--- a/style.css
+++ b/style.css
@@ -59,3 +59,55 @@ button { border-radius:6px; cursor:pointer; }
 .toast.success { background: green; }
 .toast.warning { background: orange; }
 .toast.error { background: red; }
+
+/* Loading overlay and clock-style spinner */
+#loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(5px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#spinner {
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+#spinner div {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 4px;
+  height: 20px;
+  background: var(--text-color);
+  border-radius: 2px;
+  transform-origin: 0 40px;
+  opacity: 0.2;
+  animation: spinnerFade 1.2s linear infinite;
+}
+
+@keyframes spinnerFade {
+  0% { opacity: 1; }
+  20%, 100% { opacity: 0.2; }
+}
+
+#spinner div:nth-child(1)  { transform: rotate(0deg);  animation-delay: 0s; }
+#spinner div:nth-child(2)  { transform: rotate(30deg);  animation-delay: 0.1s; }
+#spinner div:nth-child(3)  { transform: rotate(60deg);  animation-delay: 0.2s; }
+#spinner div:nth-child(4)  { transform: rotate(90deg);  animation-delay: 0.3s; }
+#spinner div:nth-child(5)  { transform: rotate(120deg); animation-delay: 0.4s; }
+#spinner div:nth-child(6)  { transform: rotate(150deg); animation-delay: 0.5s; }
+#spinner div:nth-child(7)  { transform: rotate(180deg); animation-delay: 0.6s; }
+#spinner div:nth-child(8)  { transform: rotate(210deg); animation-delay: 0.7s; }
+#spinner div:nth-child(9)  { transform: rotate(240deg); animation-delay: 0.8s; }
+#spinner div:nth-child(10) { transform: rotate(270deg); animation-delay: 0.9s; }
+#spinner div:nth-child(11) { transform: rotate(300deg); animation-delay: 1s; }
+#spinner div:nth-child(12) { transform: rotate(330deg); animation-delay: 1.1s; }


### PR DESCRIPTION
## Summary
- show a clock-style spinner over a blurred page until the app initializes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846c72d551c8325a59c335692543c4f