### PR TITLE
Fix instruction persistence without IndexedDB

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,8 +160,12 @@ let currentDescPath = null;
 
 function loadInstructions(){
     if(!db){
-        log('loadInstructions skipped, db not initialized');
-        instructionsData = [];
+        log('loadInstructions skipped, db not initialized; using localStorage');
+        try {
+            instructionsData = JSON.parse(localStorage.getItem('instructions') || '[]');
+        } catch(err) {
+            instructionsData = [];
+        }
         renderInstructions();
         return;
     }
@@ -170,6 +174,7 @@ function loadInstructions(){
     const req = store.getAll();
     req.onsuccess = () => {
         instructionsData = req.result || [];
+        localStorage.setItem('instructions', JSON.stringify(instructionsData));
         renderInstructions();
     };
 }
@@ -238,8 +243,17 @@ async function saveInstruction(){
         await openDB();
     }
     if(!db){
-        log('saveInstruction aborted, db still unavailable');
-        showToast('Database unavailable','error');
+        log('saveInstruction using localStorage fallback');
+        if(currentInstructionId){
+            const idx = instructionsData.findIndex(i=>i.id===currentInstructionId);
+            if(idx!==-1) instructionsData[idx] = {id:currentInstructionId,title,text};
+        } else {
+            const nextId = instructionsData.reduce((max,i)=>Math.max(max,i.id||0),0)+1;
+            instructionsData.push({id:nextId,title,text});
+        }
+        localStorage.setItem('instructions', JSON.stringify(instructionsData));
+        loadInstructions();
+        closeInstructionModal();
         return;
     }
     const store = db.transaction('instructions','readwrite').objectStore('instructions');
@@ -254,8 +268,10 @@ async function saveInstruction(){
 function deleteInstruction(){
     if(currentInstructionId){
         if(!db){
-            log('deleteInstruction skipped, db not initialized');
-            showToast('Database unavailable','error');
+            log('deleteInstruction skipped, db not initialized; using localStorage');
+            instructionsData = instructionsData.filter(i=>i.id!==currentInstructionId);
+            localStorage.setItem('instructions', JSON.stringify(instructionsData));
+            loadInstructions();
             closeInstructionModal();
             return;
         }


### PR DESCRIPTION
## Summary
- add localStorage fallback when IndexedDB fails
- persist instructions to localStorage as backup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca79a8a88325a5840bf164181107