### PR TITLE
Fix instruction toggle spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,6 +27,7 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 .card.dragging { opacity:0.5; }
 #desc-tree ul{ list-style:none; padding-left:20px; }
 .desc-status{ margin-left:4px; }
+.instruction-toggle{ margin-right:4px; }
 #copy-btn { margin-top:10px; width:90%; }
 #instruction-modal { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
 


### PR DESCRIPTION
## Summary
- give instruction checkboxes a margin so text aligns with file tree spacing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846cf8ae4c88325afa14f627dfd23c8