### PR TITLE
Remove refresh button and adjust settings style

### DIFF
--- a/app.js
+++ b/app.js
@@ -880,7 +880,6 @@ async function init(){
     document.getElementById('select-all-btn').addEventListener('click', selectAll);
     document.getElementById('deselect-all-btn').addEventListener('click', deselectAll);
     document.getElementById('file-tree').addEventListener('change', handleFolderToggle);
-    document.getElementById('refresh-btn').addEventListener('click', loadFileTree);
     document.getElementById('theme-select').addEventListener('change', handleThemeChange);
     document.getElementById('settings-modal').addEventListener('click', (e) => { log('settings-modal background click'); closeSettings(e); });
     document.getElementById('settings-content').addEventListener('click', e=>e.stopPropagation());

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
             </span>
             <span id="repo-label">No repo selected</span>
             <span id="branch-label"></span>
-            <button id="refresh-btn" title="Refresh">&#x21bb;</button>
         </div>
         <button id="settings-btn" title="Settings">&#9881;</button>
     </div>

--- a/style.css
+++ b/style.css
@@ -52,6 +52,14 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 .big-btn { font-size: 1.1em; padding: 10px 16px; border-radius:6px; }
 .small-btn { font-size: 0.9em; padding: 4px 8px; border-radius:6px; }
 button { border-radius:6px; cursor:pointer; }
+#settings-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+  font-size: 1.4em;
+  padding: 2px 6px;
+  line-height: 1;
+}
 .icon { width:20px; height:20px; vertical-align:middle; margin-right:4px; }
 #auth-section input { width: 100%; padding: 4px; margin-bottom: 6px; }
 .instructions { font-size: 0.9em; line-height: 1.4; }


### PR DESCRIPTION
## Summary
- remove the unused refresh button
- style the settings button with a transparent background and theme-aware color

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846d04fc17883259174c01d1daa0a7f