### PR TITLE
Add Google LLM option and dynamic model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,5 @@ Simply deploy this repository. Netlify runs `generate-config.js` which writes `c
 
 ### File Descriptions via LLM
 
-Use **Generate Descriptions** in the File Descriptions column to have an LLM analyze each file and produce detailed summaries. Configure your preferred provider and API key under **Settings → LLM API**. Requests can run asynchronously or sequentially depending on your choice.
 
-Token counts in the toast are approximated by characters/4.7.
+Use **Generate Descriptions** in the File Descriptions column to have an LLM analyze each file and produce detailed summaries. Configure your preferred provider, model and API key under **Settings → LLM API**. Requests can run asynchronously or sequentially depending on your choice.

--- a/index.html
+++ b/index.html
@@ -99,9 +99,12 @@
                     <select id="llm-provider-select">
                         <option value="openai">OpenAI</option>
                         <option value="anthropic">Anthropic</option>
+                        <option value="google">Google</option>
                     </select>
                     <label for="llm-api-key">API Key:</label>
                     <input id="llm-api-key" type="password">
+                    <label for="llm-model-select">Model:</label>
+                    <select id="llm-model-select"></select>
                     <label><input type="checkbox" id="llm-async"> Send requests asynchronously</label>
                     <button id="llm-save-btn" class="small-btn">Save</button>
                 </div>


### PR DESCRIPTION
## Summary
- add Google to the list of LLM providers
- allow selecting model for each provider
- fetch available models via provider APIs
- update description generation to support multiple providers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846d7b5216083258c7210cdc9b86dc5