### PR TITLE
Handle LLM failures and CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A simple client-side web app to browse and copy files from your GitHub repositor
 
 ## Deploying on Netlify
 
-Simply deploy this repository. Netlify runs `generate-config.js` which writes `config.js` and exposes a serverless function at `/.netlify/functions/exchange`.
+Simply deploy this repository. Netlify runs `generate-config.js` which writes `config.js` and exposes serverless functions:
+`/.netlify/functions/exchange` for GitHub OAuth and `/.netlify/functions/llm-proxy` for LLM API calls.
+
+**Note:** Browsers cannot call most LLM APIs directly because they lack the required CORS headers. The included `llm-proxy` function forwards requests to your provider and avoids these CORS issues. No keys are stored on the server – the proxy just relays your request.
 
 ## Usage
 

--- a/app.js
+++ b/app.js
@@ -677,23 +677,42 @@ function updateDescStatus(path){
 }
 
 async function callLLM(prompt){
-    if(llmProvider === 'openai'){
-        const body = {model: llmModel || 'gpt-3.5-turbo',messages:[{role:'system',content:'You generate detailed descriptions of project files.'},{role:'user',content:prompt}]};
-        const res = await fetch('https://api.openai.com/v1/chat/completions',{method:'POST',headers:{'Content-Type':'application/json','Authorization':`Bearer ${llmApiKey}`},body:JSON.stringify(body)});
-        const data = await res.json();
-        return (data.choices && data.choices[0].message.content) || '';
-    } else if(llmProvider === 'anthropic'){
-        const body = {model: llmModel || 'claude-3-haiku-20240307',messages:[{role:'user',content:prompt}],max_tokens:1024};
-        const res = await fetch('https://api.anthropic.com/v1/messages',{method:'POST',headers:{'Content-Type':'application/json','x-api-key':llmApiKey,'anthropic-version':'2023-06-01'},body:JSON.stringify(body)});
-        const data = await res.json();
-        return (data.content && data.content[0] && data.content[0].text) || '';
-    } else if(llmProvider === 'google'){
-        const body = {contents:[{role:'user',parts:[{text:prompt}]}]};
-        const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${llmModel || 'gemini-pro'}:generateContent?key=${llmApiKey}`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
-        const data = await res.json();
-        return (data.candidates && data.candidates[0] && data.candidates[0].content.parts[0].text) || '';
+    try{
+        if(window.LLM_PROXY_URL){
+            const resp=await fetch(window.LLM_PROXY_URL,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({provider:llmProvider,model:llmModel,prompt,apiKey:llmApiKey})});
+            if(!resp.ok) throw new Error('Proxy request failed');
+            const data=await resp.json();
+            if(llmProvider==='openai') return (data.choices && data.choices[0].message.content) || '';
+            if(llmProvider==='anthropic') return (data.content && data.content[0] && data.content[0].text) || '';
+            if(llmProvider==='google') return (data.candidates && data.candidates[0] && data.candidates[0].content.parts[0].text) || '';
+            return '';
+        }
+        if(llmProvider === 'openai'){
+            const body = {model: llmModel || 'gpt-3.5-turbo',messages:[{role:'system',content:'You generate detailed descriptions of project files.'},{role:'user',content:prompt}]};
+            const res = await fetch('https://api.openai.com/v1/chat/completions',{method:'POST',headers:{'Content-Type':'application/json','Authorization':`Bearer ${llmApiKey}`},body:JSON.stringify(body)});
+            const data = await res.json();
+            return (data.choices && data.choices[0].message.content) || '';
+        } else if(llmProvider === 'anthropic'){
+            const body = {model: llmModel || 'claude-3-haiku-20240307',messages:[{role:'user',content:prompt}],max_tokens:1024};
+            const res = await fetch('https://api.anthropic.com/v1/messages',{method:'POST',headers:{'Content-Type':'application/json','x-api-key':llmApiKey,'anthropic-version':'2023-06-01'},body:JSON.stringify(body)});
+            const data = await res.json();
+            return (data.content && data.content[0] && data.content[0].text) || '';
+        } else if(llmProvider === 'google'){
+            const body = {contents:[{role:'user',parts:[{text:prompt}]}]};
+            const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${llmModel || 'gemini-pro'}:generateContent?key=${llmApiKey}`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+            const data = await res.json();
+            return (data.candidates && data.candidates[0] && data.candidates[0].content.parts[0].text) || '';
+        }
+        return '';
+    }catch(err){
+        log('callLLM error',err);
+        if(err.message && err.message.includes('Failed to fetch')){
+            showToast('LLM request blocked by CORS','error',4,40,220,'upper middle');
+        }else{
+            showToast('LLM request failed','error',3,40,200,'upper middle');
+        }
+        throw err;
     }
-    return '';
 }
 
 async function generateDescriptions(){
@@ -724,7 +743,7 @@ async function generateDescriptions(){
     let asyncFailed=false;
     if(llmAsync){
         try{ await Promise.all(pending.map(run)); }
-        catch(err){ asyncFailed=true; log('async gen failed',err); }
+        catch(err){ asyncFailed=true; log('async gen failed',err); showToast('LLM request failed','error',3,40,200,'upper middle'); }
     }
     if(!llmAsync || asyncFailed){
         for(const f of pending){

--- a/config.js
+++ b/config.js
@@ -1,1 +1,2 @@
 window.EXCHANGE_URL = "/.netlify/functions/exchange";
+window.LLM_PROXY_URL = "/.netlify/functions/llm-proxy";

--- a/generate-config.js
+++ b/generate-config.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
 const exchange = '/.netlify/functions/exchange';
-const content = `window.EXCHANGE_URL = "${exchange}";\n`;
+const llmProxy = '/.netlify/functions/llm-proxy';
+const content = `window.EXCHANGE_URL = "${exchange}";\nwindow.LLM_PROXY_URL = "${llmProxy}";\n`;
 fs.writeFileSync('config.js', content);

--- a/netlify/functions/llm-proxy.js
+++ b/netlify/functions/llm-proxy.js
@@ -1,0 +1,49 @@
+exports.handler = async function(event) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+  try {
+    const { provider, model, prompt, apiKey } = JSON.parse(event.body || '{}');
+    if (!provider || !apiKey || !prompt) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing parameters' }) };
+    }
+    let url;
+    let body;
+    let headers = { 'Content-Type': 'application/json' };
+    if (provider === 'openai') {
+      url = 'https://api.openai.com/v1/chat/completions';
+      body = JSON.stringify({
+        model: model || 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'You generate detailed descriptions of project files.' },
+          { role: 'user', content: prompt }
+        ]
+      });
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    } else if (provider === 'anthropic') {
+      url = 'https://api.anthropic.com/v1/messages';
+      body = JSON.stringify({
+        model: model || 'claude-3-haiku-20240307',
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 1024
+      });
+      headers['x-api-key'] = apiKey;
+      headers['anthropic-version'] = '2023-06-01';
+    } else if (provider === 'google') {
+      url = `https://generativelanguage.googleapis.com/v1beta/models/${model || 'gemini-pro'}:generateContent?key=${apiKey}`;
+      body = JSON.stringify({ contents: [{ role: 'user', parts: [{ text: prompt }] }] });
+    } else {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Unknown provider' }) };
+    }
+    const resp = await fetch(url, { method: 'POST', headers, body });
+    const data = await resp.text();
+    return {
+      statusCode: resp.status,
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      body: data
+    };
+  } catch (err) {
+    console.error('LLM proxy error', err);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Proxy failed' }) };
+  }
+};


### PR DESCRIPTION
## Summary
- add new `llm-proxy` Netlify function for LLM requests
- generate `LLM_PROXY_URL` in config
- use proxy in `callLLM` and surface CORS failures via toast
- show red toast when async generation fails
- document the proxy in README

## Testing
- `node -e "require('./netlify/functions/llm-proxy.js');"`
- `npm start` *(fails: MODULE_NOT_FOUND express)*

------
https://chatgpt.com/codex/tasks/task_e_6846e927e844832588b96d022d642c4c