### PR TITLE
Add drag hint for sortable output cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
 
     <div id="output-col">
         <h3 id="output-title">Output <span id="total-tokens"></span></h3>
+        <div id="drag-hint" class="instructions">Drag cards to reorder</div>
         <div id="output-cards"></div>
         <button id="copy-btn" class="big-btn">📋 Copy Selected</button>
     </div>

--- a/style.css
+++ b/style.css
@@ -29,7 +29,9 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 }
 #output-col { padding:20px; text-align:center; margin-top:20px; }
 #output-cards { display:flex; flex-direction:column; align-items:center; gap:10px; }
-.card { background:var(--modal-bg); padding:10px; border-radius:6px; width:80%; max-width:500px; cursor:grab; }
+#drag-hint { margin-bottom: 6px; opacity: 0.7; }
+.card { background:var(--modal-bg); padding:10px; border-radius:6px; width:80%; max-width:500px; cursor:grab; position:relative; }
+.card::after { content:'\2195'; position:absolute; right:8px; top:50%; transform:translateY(-50%); opacity:0.6; }
 .card.dragging { opacity:0.5; }
 #desc-tree ul{ list-style:none; padding-left:20px; margin-top:0; }
 .desc-status{ margin-left:4px; }


### PR DESCRIPTION
## Summary
- indicate that output cards are draggable for reordering
- show a handle icon on each card

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6846ecb4ed108325aefe084050997bf7