### PR TITLE
Implement selection persistence and improved UI hints

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,9 +29,10 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 }
 #output-col { padding:20px; text-align:center; margin-top:20px; }
 #output-cards { display:flex; flex-direction:column; align-items:center; gap:10px; }
-#drag-hint { margin-bottom: 6px; opacity: 0.7; }
+#drag-hint { margin-bottom: 6px; opacity: 0.7; display:none; }
 .card { background:var(--modal-bg); padding:10px; border-radius:6px; width:80%; max-width:500px; cursor:grab; position:relative; }
-.card::after { content:'\2195'; position:absolute; right:8px; top:50%; transform:translateY(-50%); opacity:0.6; }
+.card::after { content:'\2195'; position:absolute; right:8px; top:50%; transform:translateY(-50%); opacity:0.6; display:none; }
+.multi-card .card::after { display:block; }
 .card.dragging { opacity:0.5; }
 #desc-tree ul{ list-style:none; padding-left:20px; margin-top:0; }
 .desc-status{ margin-left:4px; }


### PR DESCRIPTION
## Summary
- hide drag hint and arrows until multiple cards exist
- remember selected files and instructions per repo/branch using IndexedDB
- restore saved selections when repository is loaded
- show logs around copy operation and selection saving

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846f16f3dd883259507116957359001