### PR TITLE
Add description selection controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -1010,6 +1010,16 @@ function deselectAll(){
     updateOutputCards();
 }
 
+function selectAllDesc(){
+    document.querySelectorAll('#desc-tree input[type=checkbox]').forEach(cb=>cb.checked=true);
+    updateOutputCards();
+}
+
+function deselectAllDesc(){
+    document.querySelectorAll('#desc-tree input[type=checkbox]').forEach(cb=>cb.checked=false);
+    updateOutputCards();
+}
+
 function getSelectedPaths(){
     const checkboxes=document.querySelectorAll('#file-tree input[type=checkbox]:checked');
     return Array.from(checkboxes)
@@ -1115,6 +1125,10 @@ async function init(){
     document.getElementById('copy-btn').addEventListener('click', copySelected);
     document.getElementById('select-all-btn').addEventListener('click', selectAll);
     document.getElementById('deselect-all-btn').addEventListener('click', deselectAll);
+    const dsa=document.getElementById('desc-select-all-btn');
+    if(dsa) dsa.addEventListener('click', selectAllDesc);
+    const dda=document.getElementById('desc-deselect-all-btn');
+    if(dda) dda.addEventListener('click', deselectAllDesc);
     document.getElementById('file-tree').addEventListener('change', handleFolderToggle);
     document.getElementById('theme-select').addEventListener('change', handleThemeChange);
     document.getElementById('settings-modal').addEventListener('click', (e) => { log('settings-modal background click'); closeSettings(e); });

--- a/index.html
+++ b/index.html
@@ -46,9 +46,16 @@
         </div>
         <div id="descriptions-col" class="column">
             <h3>File Descriptions</h3>
-            <button id="generate-desc-btn" class="small-btn">Generate Descriptions</button>
+            <div id="desc-select-buttons">
+                <button id="desc-select-all-btn" class="small-btn">Select All</button>
+                <button id="desc-deselect-all-btn" class="small-btn">Deselect All</button>
+            </div>
             <div id="generate-status" class="instructions"></div>
             <div id="desc-tree"></div>
+            <div id="generate-desc-option">
+                <hr class="section-divider">
+                <button id="generate-desc-btn" class="small-btn">Generate Descriptions</button>
+            </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -21,6 +21,7 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 .column { flex:1; padding:20px; border-right:1px solid #ccc; }
 .column:last-child { border-right:none; }
 #select-buttons { margin:10px 0; display:flex; gap:10px; }
+#desc-select-buttons { margin:10px 0; display:flex; gap:10px; }
 #create-instruction {
   margin-bottom: 10px;
 }
@@ -53,6 +54,9 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
   margin: 10px auto;
 }
 #line-number-option {
+  text-align: center;
+}
+#generate-desc-option {
   text-align: center;
 }
 .settings-tab {


### PR DESCRIPTION
## Summary
- let users select/deselect all description checkboxes
- relocate the **Generate Descriptions** button under the description tree
- update layout and styles for new controls

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846f84133f08325bb7742abef570986