### PR TITLE
Implement task store schema upgrade

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,13 +29,14 @@ function openDB() {
         let finished = false;
         const done = () => { if(!finished){ finished = true; resolve(); } };
         try {
-            const req = indexedDB.open('contextplus', 3);
+            const req = indexedDB.open('contextplus', 4);
             req.onupgradeneeded = e => {
                 const db = e.target.result;
                 if(!db.objectStoreNames.contains('settings')) db.createObjectStore('settings');
                 if(!db.objectStoreNames.contains('instructions')) db.createObjectStore('instructions', { keyPath: 'id', autoIncrement: true });
                 if(db.objectStoreNames.contains('descriptions')) db.deleteObjectStore('descriptions');
                 db.createObjectStore('descriptions', { keyPath: ['repo','branch','path'] });
+                if(!db.objectStoreNames.contains('tasks')) db.createObjectStore('tasks', { keyPath: 'id', autoIncrement: true });
             };
             req.onsuccess = e => {
                 db = e.target.result;

--- a/docs/CODEX_PLAN.md
+++ b/docs/CODEX_PLAN.md
@@ -9,7 +9,7 @@ It explains the existing architecture, coding conventions, new UX requirements, 
 
 Use the following list to track completion status for each task.
 
-- [ ] **Task 0** – IDB schema bump → `tasks` store
+- [x] **Task 0** – IDB schema bump → `tasks` store
 - [ ] **Task 1** – AI Instructions UI & validation
 - [ ] **Task 2** – Generate Updates button
 - [ ] **Task 3** – `buildContextBundle()` helper


### PR DESCRIPTION
## Summary
- bump IndexedDB version and add `tasks` store
- mark task completion in CODEX_PLAN progress checklist

## Testing
- `npm install`
- `node generate-config.js`
- `npm start` *(fails: server starts and waits at http://localhost:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68497a8531a48325a229c41363d0aa93