### PR TITLE
Implement preset seeding and prompt builder

### DIFF
--- a/docs/CODEX_PLAN.md
+++ b/docs/CODEX_PLAN.md
@@ -14,8 +14,8 @@ Use the following list to track completion status for each task.
 - [x] **Task 2** – Generate Updates button
 - [x] **Task 3** – `buildContextBundle()` helper
 - [x] **Task 4** – Prompt Preview modal
-- [ ] **Task 5** – Seed "Code" & "Ask" presets
-- [ ] **Task 6** – `buildPrompt()`
+- [x] **Task 5** – Seed "Code" & "Ask" presets
+- [x] **Task 6** – `buildPrompt()`
 - [ ] **Task 7** – LLM call & Task persistence
 - [ ] **Task 8** – Parse model output & diff UI
 - [ ] **Task 9** – `applyPatchLowLevel()` plumbing

--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@
             <div class="modal-buttons">
                 <button id="instruction-save" class="small-btn">Save</button>
                 <button id="instruction-delete" class="small-btn">Delete</button>
+                <button id="instruction-restore" class="small-btn hidden">Restore Default</button>
                 <button id="instruction-close" class="small-btn">Close</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- seed default `Code` and `Ask` instruction presets
- add restore button to instruction modal
- generate a prompt from context bundles

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684987cb60d483258399cbe52ef09c4a