### PR TITLE
Add sequential task names and deletion

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
             <textarea id="task-modal-diff" readonly rows="12"></textarea>
             <div class="modal-buttons">
                 <button id="task-pr-btn" class="small-btn">Create Pull Request</button>
+                <button id="task-delete-btn" class="small-btn">Delete</button>
                 <button id="task-modal-close" class="small-btn">Close</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- name tasks sequentially per repo when creating them
- allow rows to open the task modal
- add button to delete tasks from IndexedDB

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6849c03bf4e083258364d9e65cb9aab3