### PR TITLE
Improve light mode contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
   --text-color: #000000;
   --top-bar-bg: #f0f0f0;
   --modal-bg: #ffffff;
+  --card-bg: #f8f8f8;
   --overlay-bg: rgba(255, 255, 255, 0.6);
 }
 
@@ -11,6 +12,7 @@
   --text-color: #ffffff;
   --top-bar-bg: #333333;
   --modal-bg: #444444;
+  --card-bg: #444444;
   --overlay-bg: rgba(0, 0, 0, 0.6);
 }
 
@@ -33,7 +35,7 @@ body { font-family: Arial, sans-serif; margin: 0; background: var(--bg-color); c
 #ai-instructions { width:80%; max-width:600px; }
 #output-cards { display:flex; flex-direction:column; align-items:center; gap:10px; }
 #drag-hint { margin-bottom: 6px; opacity: 0.7; display:none; }
-.card { background:var(--modal-bg); padding:10px; border-radius:6px; width:80%; max-width:500px; cursor:grab; position:relative; display:flex; flex-direction:column; gap:4px; }
+.card { background:var(--card-bg); padding:10px; border-radius:6px; width:80%; max-width:500px; cursor:grab; position:relative; display:flex; flex-direction:column; gap:4px; }
 .card-header { font-weight:bold; }
 .card::after { content:'\2195'; position:absolute; right:8px; top:50%; transform:translateY(-50%); opacity:0.6; display:none; }
 .multi-card .card::after { display:block; }


### PR DESCRIPTION
## Summary
- add new CSS variable `--card-bg`
- use the variable so output cards have a grey background in light mode

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a83c02b9483259b37cba9833a35d9